### PR TITLE
Проброс возникающих исключений при создании сущностей.

### DIFF
--- a/src/ImportData/Logic/BusinessLogic.cs
+++ b/src/ImportData/Logic/BusinessLogic.cs
@@ -108,8 +108,9 @@ namespace ImportData
 
         if (ex.Message.Contains("(Unauthorized)"))
           throw new FoundMatchesException("Проверьте коррекность указанной учетной записи.");
+
+        throw ex;
       }
-      return null;
     }
 
     /// <summary>
@@ -135,8 +136,8 @@ namespace ImportData
         if (ex.Message.Contains("(Unauthorized)"))
           throw new FoundMatchesException("Проверьте коррекность указанной учетной записи.");
 
+        throw ex;
       }
-      return null;
     }
 
     /// <summary>
@@ -162,8 +163,9 @@ namespace ImportData
 
         if (ex.Message.Contains("(Unauthorized)"))
           throw new FoundMatchesException("Проверьте коррекность указанной учетной записи.");
+
+      throw ex;
       }
-      return null;
     }
     #endregion
 


### PR DESCRIPTION
В методах создания сущностей в блоках catch обрабатываются не все ошибки. Это может приводить к тому, что исключение просто пропадёт в этом блоке и утилита сообщит об успешном импорте, хотя импорт сущности не проходит.
Такие ошибки тяжело работы утилиты тяжело отслеживать, поэтому если исключение происходит, то пусть утилита об этом нам сообщит.