### PR TITLE
Фильтрация по дате регистрации при поиске документа

### DIFF
--- a/src/ImportData/Entities/EDocs/CompanyDirective.cs
+++ b/src/ImportData/Entities/EDocs/CompanyDirective.cs
@@ -151,9 +151,11 @@ namespace ImportData
       try
       {
         var isNewCompanyDirective = false;
-        var companyDirective = BusinessLogic.GetEntityWithFilter<ICompanyDirective>(x => x.RegistrationNumber == regNumber && 
+        var companyDirectives = BusinessLogic.GetEntitiesWithFilter<ICompanyDirective>(x => x.RegistrationNumber == regNumber && 
             x.RegistrationDate.Value.ToString("d") == regDate.ToString("d") &&
             x.DocumentRegister.Id == documentRegisters.Id, exceptionList, logger, true);
+
+        var companyDirective = (ICompanyDirective)IOfficialDocuments.GetDocumentByRegistrationDate(companyDirectives, regDate, logger, exceptionList);
         if (companyDirective == null)
         {
           companyDirective = new ICompanyDirective();

--- a/src/ImportData/Entities/EDocs/Contract.cs
+++ b/src/ImportData/Entities/EDocs/Contract.cs
@@ -6,6 +6,7 @@ using ImportData.IntegrationServicesClient.Models;
 using System.IO;
 using DocumentFormat.OpenXml.Drawing.Charts;
 using ImportData.Entities.Databooks;
+using System.Linq;
 
 namespace ImportData
 {
@@ -249,12 +250,13 @@ namespace ImportData
       try
       {
         var isNewContract = false;
-        var contract = BusinessLogic.GetEntityWithFilter<IContracts>(x => x.RegistrationNumber != null &&
+        var contracts = BusinessLogic.GetEntitiesWithFilter<IContracts>(x => x.RegistrationNumber != null &&
             x.RegistrationNumber == regNumber &&
             x.RegistrationDate.Value.ToString("d") == regDate.ToString("d") &&
             x.Counterparty.Id == counterparty.Id &&
             x.DocumentRegister.Id == documentRegisters.Id, exceptionList, logger, true);
 
+        var contract = (IContracts)IOfficialDocuments.GetDocumentByRegistrationDate(contracts, regDate, logger, exceptionList);
         if (contract == null)
         {
           contract = new IContracts();

--- a/src/ImportData/Entities/EDocs/IncomingLetter.cs
+++ b/src/ImportData/Entities/EDocs/IncomingLetter.cs
@@ -147,9 +147,11 @@ namespace ImportData
       try
       {
         var isNewIncomingLetter = false;
-        var incomingLetter = BusinessLogic.GetEntityWithFilter<IIncomingLetters>(x => x.RegistrationNumber == regNumber &&
+        var incomingLetters = BusinessLogic.GetEntitiesWithFilter<IIncomingLetters>(x => x.RegistrationNumber == regNumber &&
 			x.RegistrationDate.Value.ToString("d") == regDate.ToString("d") &&
 			x.DocumentRegister.Id == documentRegisters.Id, exceptionList, logger, true);
+
+        var incomingLetter = (IIncomingLetters)IOfficialDocuments.GetDocumentByRegistrationDate(incomingLetters, regDate, logger, exceptionList);
         if (incomingLetter == null)
         {
           incomingLetter = new IIncomingLetters();

--- a/src/ImportData/Entities/EDocs/Order.cs
+++ b/src/ImportData/Entities/EDocs/Order.cs
@@ -159,9 +159,11 @@ namespace ImportData
       try
       {
         var isNewOrder = false;
-        var order = BusinessLogic.GetEntityWithFilter<IOrders>(x => x.RegistrationNumber == regNumber &&
+        var orders = BusinessLogic.GetEntitiesWithFilter<IOrders>(x => x.RegistrationNumber == regNumber &&
 			x.RegistrationDate.Value.ToString("d") == regDate.ToString("d") &&
 			x.DocumentRegister.Id == documentRegisters.Id, exceptionList, logger, true);
+
+        var order = (IOrders)IOfficialDocuments.GetDocumentByRegistrationDate(orders, regDate, logger, exceptionList);
         if (order == null)
         {
           order = new IOrders();

--- a/src/ImportData/Entities/EDocs/OutgoingLetter.cs
+++ b/src/ImportData/Entities/EDocs/OutgoingLetter.cs
@@ -132,9 +132,11 @@ namespace ImportData
       {
         var isNewOutgoingLetter = false;
         var regDateBeginningOfDay = BeginningOfDay(regDate.UtcDateTime);
-        var outgoingLetter = BusinessLogic.GetEntityWithFilter<IOutgoingLetters>(x => x.RegistrationNumber == regNumber &&
+        var outgoingLetters = BusinessLogic.GetEntitiesWithFilter<IOutgoingLetters>(x => x.RegistrationNumber == regNumber &&
 			x.RegistrationDate.Value.ToString("d") == regDate.ToString("d") &&
 			x.DocumentRegister.Id == documentRegisters.Id, exceptionList, logger, true);
+        
+        var outgoingLetter = (IOutgoingLetters)IOfficialDocuments.GetDocumentByRegistrationDate(outgoingLetters, regDate, logger, exceptionList);
         if (outgoingLetter == null)
         {
           outgoingLetter = new IOutgoingLetters();

--- a/src/ImportData/Entities/EDocs/SupAgreement.cs
+++ b/src/ImportData/Entities/EDocs/SupAgreement.cs
@@ -263,10 +263,12 @@ namespace ImportData
       {
         var isNewSupAgreement = false;
         var regDateBeginningOfDay = BeginningOfDay(regDate.UtcDateTime);
-        var supAgreement = BusinessLogic.GetEntityWithFilter<ISupAgreements>(x => x.RegistrationNumber == regNumber &&
+        var supAgreements = BusinessLogic.GetEntitiesWithFilter<ISupAgreements>(x => x.RegistrationNumber == regNumber &&
 			x.RegistrationDate.Value.ToString("d") == regDate.ToString("d") &&
 			x.Counterparty.Id == counterparty.Id &&
             x.DocumentRegister.Id == documentRegisters.Id, exceptionList, logger, true);
+
+        var supAgreement = (ISupAgreements)IOfficialDocuments.GetDocumentByRegistrationDate(supAgreements, regDate, logger, exceptionList);
         if (supAgreement == null)
         {
           supAgreement = new ISupAgreements();


### PR DESCRIPTION
Исправления:
1. Исправлена ошибка поиска ведущего документа: ранее не учитывалась дата регистрации.
2. Исправлен поиск обновляемого документа (ранее тоже не учитывалась дата регистрации).

Изменения: после получения списка документов по условиям делается доп. фильтрация по дате регистрации, т.к. запрос ее не учитывает