### PR TITLE
Поиск НОР по ИНН учетом КПП

### DIFF
--- a/src/ImportData/Entities/Databooks/BusinessUnit.cs
+++ b/src/ImportData/Entities/Databooks/BusinessUnit.cs
@@ -158,7 +158,7 @@ namespace ImportData
                 var isNewBU = false;
 
                 if (ignoreDuplicates.ToLower() != Constants.ignoreDuplicates.ToLower())
-                    businessUnit = BusinessLogic.GetEntityWithFilter<IBusinessUnits>(x => x.Name == name || x.TIN == tin || x.PSRN == psrn, exceptionList, logger);
+                    businessUnit = BusinessLogic.GetEntityWithFilter<IBusinessUnits>(x => x.Name == name || (x.TIN == tin && x.TRRC == trrc) || x.PSRN == psrn, exceptionList, logger);
 
                 if (businessUnit is null)
                 {


### PR DESCRIPTION
Исправлена ошибка: при импорте НОР с одинаковым ИНН, но разным наименованием и КПП в RX загружается только одна организация - последняя в файле импорта.