### PR TITLE
Правка бага - необязательное пустое ссылочное поле вызывает ошибку импорта

### DIFF
--- a/src/ImportData/Entities/Entity.cs
+++ b/src/ImportData/Entities/Entity.cs
@@ -91,9 +91,17 @@ namespace ImportData
           // Работа с полями-сущностями.
           if (options.Type == PropertyType.Entity || options.Type == PropertyType.EntityWithCreate)
           {
-            // Добавляем поля и значения для поиска или создания сущностей.
-            var propertiesForSearch = GetPropertiesForSearch(property.PropertyType, exceptionList, logger);
             var entityName = (string)variableForParameters;
+            // баг - при поиске необязательного ссылочного объекта, у которого название для поиска является обязателньым - ошибка становится критичной
+            // hack: если необязательное поле пустое - пропускаем, нет смысла дальше искать
+            if (!options.IsRequired() && string.IsNullOrEmpty(entityName))
+            {
+              ResultValues.Add(property.Name, null);
+              continue;
+            }
+            
+            // Добавляем поля и значения для поиска или создания сущностей.
+            var propertiesForSearch = GetPropertiesForSearch(property.PropertyType, exceptionList, logger);            
 
             if (propertiesForSearch == null)
               propertiesForSearch = new Dictionary<string, string>();


### PR DESCRIPTION
Пример для воспроизведения проблемы - импорт организаций, не указан населенный пункт или регион.

Суть проблемы - в разработке эти поля не являются обязательными, они ссылочные, но при попытке найти населенный пункт обращаемся к сущности Cities, для которой поле Name, по которому ищем - обязательное. В итоге из сущности Cities генерируется исключение из-за отсутствия значения для обязательного поля при поиске населённого пункта.

Добавил проверку - если ссылочное поле пустое и не обязательное, то вглубь не идём.