### PR TITLE
Исправлена ошибка SqlDateTime overflow. Must be between 1/1/1753 12:0…

### DIFF
--- a/src/ImportData/Entities/Entity.cs
+++ b/src/ImportData/Entities/Entity.cs
@@ -99,9 +99,9 @@ namespace ImportData
               ResultValues.Add(property.Name, null);
               continue;
             }
-            
+
             // Добавляем поля и значения для поиска или создания сущностей.
-            var propertiesForSearch = GetPropertiesForSearch(property.PropertyType, exceptionList, logger);            
+            var propertiesForSearch = GetPropertiesForSearch(property.PropertyType, exceptionList, logger);
 
             if (propertiesForSearch == null)
               propertiesForSearch = new Dictionary<string, string>();
@@ -151,7 +151,7 @@ namespace ImportData
         entity = (IEntityBase)MethodCall(EntityType, Constants.EntityActions.CreateOrUpdate, entity, isNewEntity, isBatch, exceptionList, logger);
 
         // При необходимость дозаполнить свойства-коллекции.
-        if(entity != null)
+        if (entity != null)
           FillCollections(exceptionList, logger);
       }
       catch (Exception ex)
@@ -244,7 +244,7 @@ namespace ImportData
             continue;
 
           if (property.PropertyType == typeof(double))
-          { 
+          {
             if (string.IsNullOrWhiteSpace(ResultValues[property.Name].ToString()))
               property.SetValue(entity, 0d);
             else
@@ -264,22 +264,20 @@ namespace ImportData
     /// <param name="culture">Культура.</param>
     /// <returns>Преобразованная дата.</returns>
     /// <exception cref="FormatException" />
-    private DateTimeOffset ParseDate(string value, NumberStyles style, CultureInfo culture)
+    private DateTimeOffset? ParseDate(string value, NumberStyles style, CultureInfo culture)
     {
-      if (!string.IsNullOrEmpty(value))
-      {
-        DateTimeOffset date;
-        if (DateTimeOffset.TryParse(value.Trim(), culture.DateTimeFormat, DateTimeStyles.AssumeUniversal, out date))
-          return date;
+      if (string.IsNullOrEmpty(value))
+        return null;
 
-        var dateDouble = 0.0;
-        if (double.TryParse(value.Trim(), style, culture, out dateDouble))
-          return new DateTimeOffset(DateTime.FromOADate(dateDouble), TimeSpan.Zero);
+      DateTimeOffset date;
+      if (DateTimeOffset.TryParse(value.Trim(), culture.DateTimeFormat, DateTimeStyles.AssumeUniversal, out date))
+        return date;
 
-        throw new FormatException("Неверный формат строки.");
-      }
-      else
-        return DateTimeOffset.MinValue;
+      var dateDouble = 0.0;
+      if (double.TryParse(value.Trim(), style, culture, out dateDouble))
+        return new DateTimeOffset(DateTime.FromOADate(dateDouble), TimeSpan.Zero);
+
+      throw new FormatException("Неверный формат строки.");
     }
 
     /// <summary>

--- a/src/ImportData/IntegrationServicesClient/Models/IContractualDocuments.cs
+++ b/src/ImportData/IntegrationServicesClient/Models/IContractualDocuments.cs
@@ -6,8 +6,8 @@ namespace ImportData.IntegrationServicesClient.Models
 {
   public class IContractualDocuments : IOfficialDocuments
   {
-    private DateTimeOffset? validFrom;
-    private DateTimeOffset? validTill;
+    private DateTimeOffset? validFrom = null;
+    private DateTimeOffset? validTill = null;
     public IEmployees Assignee { get; set; }
 
     [PropertyOptions("Наша организация", RequiredType.Required, PropertyType.Entity, AdditionalCharacters.ForSearch)]
@@ -25,14 +25,14 @@ namespace ImportData.IntegrationServicesClient.Models
     public DateTimeOffset? ValidFrom
     {
       get { return validFrom; }
-      set { validFrom = value.HasValue ? new DateTimeOffset(value.Value.Date, TimeSpan.Zero) : new DateTimeOffset?(); }
+      set { validFrom = value.HasValue ? new DateTimeOffset(value.Value.Date, TimeSpan.Zero) : null; }
     }
 
     [PropertyOptions("Действует по", RequiredType.NotRequired, PropertyType.Simple, AdditionalCharacters.ForSearch)]
     public DateTimeOffset? ValidTill
     {
       get { return validTill; }
-      set { validTill = value.HasValue ? new DateTimeOffset(value.Value.Date, TimeSpan.Zero) : new DateTimeOffset?(); }
+      set { validTill = value.HasValue ? new DateTimeOffset(value.Value.Date, TimeSpan.Zero) : null; }
     }
 
     [PropertyOptions("Сумма", RequiredType.NotRequired, PropertyType.Simple)]

--- a/src/ImportData/IntegrationServicesClient/Models/ISupAgreements.cs
+++ b/src/ImportData/IntegrationServicesClient/Models/ISupAgreements.cs
@@ -28,14 +28,14 @@ namespace ImportData.IntegrationServicesClient.Models
     new public DateTimeOffset? DocumentDate
     {
       get { return documentDate; }
-      set { documentDate = value.HasValue ? new DateTimeOffset(value.Value.Date, TimeSpan.Zero) : new DateTimeOffset?(); }
+      set { documentDate = value.HasValue ? new DateTimeOffset(value.Value.Date, TimeSpan.Zero) : null; }
     }
 
     [PropertyOptions("Действует с", RequiredType.Required, PropertyType.Simple)]
     new public DateTimeOffset? ValidFrom
     {
       get { return validFrom; }
-      set { validFrom = value.HasValue ? new DateTimeOffset(value.Value.Date, TimeSpan.Zero) : new DateTimeOffset?(); }
+      set { validFrom = value.HasValue ? new DateTimeOffset(value.Value.Date, TimeSpan.Zero) : null; }
     }
 
     [PropertyOptions("Действует по", RequiredType.Required, PropertyType.Simple)]


### PR DESCRIPTION
Не удалось воспроизвести изначальную ошибку. Договоры импортируются со стандартным шаблоном. Если изменить столбец ИД журнала регистрации на Журнал регистрации, то наоборот возникают ошибки. Но пока пытался воспроизвести, починил другой баг: если не заполнены даты Действует с и Действует по, то возникает ошибка 

SqlDateTime overflow. Must be between 1/1/1753 12:00:00 AM and 12/31/9999 11:59:59 PM